### PR TITLE
Add basic job persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ docker-compose up --build
 ```bash
 curl -F "file=@scan.laz" http://localhost/api/v1/scan/job
 ```
+
+Для получения информации о загрузке:
+
+```bash
+curl http://localhost/api/v1/scan/job/<JOB_ID>
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,32 @@
 from __future__ import annotations
 
+import os
 import uuid
 from pathlib import Path
+
+from sqlalchemy import Column, String, create_engine
+from sqlalchemy.orm import declarative_base, Session
 
 from fastapi import FastAPI, File, UploadFile
 from fastapi.responses import JSONResponse
 
 DATA_DIR = Path("/data")
 DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@db:5432/bim")
+engine = create_engine(DATABASE_URL)
+Base = declarative_base()
+
+
+class ScanJob(Base):
+    __tablename__ = "scan_jobs"
+
+    id = Column(String, primary_key=True)
+    filename = Column(String, nullable=False)
+    status = Column(String, default="uploaded")
+
+
+Base.metadata.create_all(engine)
 
 app = FastAPI(title="PointCloud API", version="1.0")
 
@@ -19,5 +38,20 @@ async def create_scan_job(file: UploadFile = File(...)) -> JSONResponse:
     with file_path.open("wb") as buffer:
         content = await file.read()
         buffer.write(content)
+
+    with Session(engine) as session:
+        job = ScanJob(id=job_id, filename=file.filename)
+        session.add(job)
+        session.commit()
+
     # Placeholder for queueing background job
     return JSONResponse({"job_id": job_id})
+
+
+@app.get("/v1/scan/job/{job_id}")
+def get_scan_job(job_id: str) -> JSONResponse:
+    with Session(engine) as session:
+        job = session.get(ScanJob, job_id)
+        if not job:
+            return JSONResponse({"detail": "Job not found"}, status_code=404)
+        return JSONResponse({"job_id": job.id, "filename": job.filename, "status": job.status})

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 open3d
 pydantic
+SQLAlchemy
+psycopg2-binary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: ./backend
     volumes:
       - data:/data
+    environment:
+      DATABASE_URL: postgresql://user:password@db:5432/bim
     depends_on:
       - redis
       - db


### PR DESCRIPTION
## Summary
- persist uploaded scan jobs in a Postgres table
- expose endpoint to fetch job info
- document new endpoint
- pass database URL to backend via docker-compose

## Testing
- `python3 -m pip install -r backend/requirements.txt`
- `python3 -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684ff26a31048333bfc1da46df65e2bc